### PR TITLE
D（コンパイル時）の席替えスクリプトを追加

### DIFF
--- a/sekigae.di
+++ b/sekigae.di
@@ -1,0 +1,30 @@
+// Usage: dmd -c -J. sekigae.di
+
+import std.algorithm, std.array, std.conv, std.random, std.range, std.regex, std.stdio, std.string;
+
+auto extractDigits(string s) {
+  typeof(s) t;
+  foreach(i, c; s) if('0' <= c && c <= '9') t ~= c;
+  return t;
+}
+
+auto readNamesShuffled(alias path)() {
+  auto rng = Xorshift(__TIME__.extractDigits.to!uint);
+  auto names = import(path).chomp.split;
+  names.randomShuffle(rng);
+  return names;
+}
+
+auto formatNames(R)(R names, int nlines) {
+  auto lines = new string[](nlines);
+  foreach(col; names.chunks(nlines)) {
+      immutable len = col.map!"a.length".reduce!max;
+      foreach(i, name; col) {
+        if(lines[i].length) lines[i] ~= ' ';
+        lines[i] ~= name.leftJustify(len);
+      }
+  }
+  return lines;
+}
+
+pragma(msg, readNamesShuffled!"names.txt".formatNames(2).join('\n'));


### PR DESCRIPTION
お告げがあったので． https://twitter.com/repeatedly/status/610319015349628929

コンパイル時に時刻をシードにした乱数で並べ替えて出力します．
`formatNames`は副作用がないので #8 と同じものがコンパイル時にも動いてほしいのですが，コンパイラが文句を言うのでループに書き直しました．
